### PR TITLE
Fix unsafe

### DIFF
--- a/server/src/certificate.rs
+++ b/server/src/certificate.rs
@@ -28,15 +28,12 @@ pub fn load_private_key(path: &str) -> Result<PrivateKey, IoError> {
 
     while let Ok(Some(item)) = rustls_pemfile::read_one(&mut file) {
         if let Item::RSAKey(key) | Item::PKCS8Key(key) = item {
-            priv_key = Some(PrivateKey(key));
+            priv_key = Some(key);
         }
     }
 
-    if priv_key.is_none() {
-        priv_key = Some(PrivateKey(fs::read(path)?));
-    }
-
-    let priv_key = unsafe { priv_key.unwrap_unchecked() };
-
-    Ok(priv_key)
+    priv_key
+        .map(|i| Ok(i))
+        .unwrap_or_else(|| fs::read(path))
+        .map(PrivateKey)
 }

--- a/server/src/connection/task.rs
+++ b/server/src/connection/task.rs
@@ -4,11 +4,7 @@ use quinn::{
     Connection as QuinnConnection, ConnectionError, ReadExactError, RecvStream, SendDatagramError,
     SendStream, WriteError,
 };
-use std::{
-    io::Error as IoError,
-    net::{SocketAddr, ToSocketAddrs},
-    sync::Arc,
-};
+use std::{io::Error as IoError, net::SocketAddr, sync::Arc};
 use thiserror::Error;
 use tokio::{io, net::TcpStream};
 use tuic_protocol::{Address, Command, Response};
@@ -19,7 +15,7 @@ pub async fn connect(
     addr: Address,
 ) -> Result<(), TaskError> {
     let mut stream = None;
-    let addrs = addr.to_socket_addrs()?;
+    let addrs = addr.to_socket_addrs().await?;
 
     for addr in addrs {
         if let Ok(tcp_stream) = TcpStream::connect(addr).await {


### PR DESCRIPTION
* Remove unnecessary unsafe usage
* Avoid using `std::net::ToSocketAddrs` in async fn directly, wrapped it by `tokio::task::spawn_blocking` and use `tokio::net::lookup_host` instead.

`std::vec::IntoIter` is replaced by `Vec`, because the Iterator holds `Vec`. And `Vec::new` does not do heap allocation, so there is no cost to do so.

Therefore, 2 completely unnecessary uses of unsafe have been removed.