### PR TITLE
Support UDP packet fragmentation

### DIFF
--- a/client/src/relay/task.rs
+++ b/client/src/relay/task.rs
@@ -2,7 +2,7 @@ use super::{stream::BiStream, Address, Connection, UdpRelayMode};
 use bytes::{Bytes, BytesMut};
 use std::io::Result;
 use tokio::{io::AsyncWriteExt, sync::oneshot::Sender as OneshotSender};
-use tuic_protocol::{Address as TuicAddress, Command as TuicCommand};
+use tuic_protocol::{Address as TuicAddress, Command as TuicCommand, UdpAssocPacket};
 
 impl Connection {
     pub async fn handle_connect(self, addr: Address, tx: OneshotSender<BiStream>) {
@@ -54,17 +54,51 @@ impl Connection {
             addr: Address,
             mode: UdpRelayMode<(), ()>,
         ) -> Result<()> {
-            let cmd = TuicCommand::new_packet(assoc_id, pkt.len() as u16, TuicAddress::from(addr));
-
             match mode {
                 UdpRelayMode::Native(()) => {
-                    let mut buf = BytesMut::with_capacity(cmd.serialized_len());
-                    cmd.write_to_buf(&mut buf);
-                    buf.extend_from_slice(&pkt);
-                    let pkt = buf.freeze();
-                    conn.send_datagram(pkt)?;
+                    let frag_size = conn.fragment_size();
+                    if pkt.len() > frag_size {
+                        let frags = pkt.chunks(frag_size);
+                        let frag_cnt = frags.len();
+                        let addr = TuicAddress::from(addr);
+                        if let Some(session) = conn.udp_sessions().get(&assoc_id) {
+                            let lp_id = session.next_lp_id();
+                            for (i, frag) in frags.enumerate() {
+                                let cmd = TuicCommand::new_long_packet(
+                                    assoc_id,
+                                    frag.len() as u16,
+                                    lp_id,
+                                    i as u8,
+                                    frag_cnt as u8,
+                                    if i == 0 { Some(addr.clone()) } else { None },
+                                );
+                                log::debug!(
+                                    "[relay] [task] [associate] [{assoc_id}] [send] [{lp_id}] [{i}/{frag_cnt}]"
+                                );
+                                let mut buf = BytesMut::with_capacity(cmd.serialized_len());
+                                cmd.write_to_buf(&mut buf);
+                                buf.extend_from_slice(frag);
+                                conn.send_datagram(buf.freeze())?;
+                            }
+                        }
+                    } else {
+                        let cmd = TuicCommand::new_packet(
+                            assoc_id,
+                            pkt.len() as u16,
+                            TuicAddress::from(addr),
+                        );
+                        let mut buf = BytesMut::with_capacity(cmd.serialized_len());
+                        cmd.write_to_buf(&mut buf);
+                        buf.extend_from_slice(&pkt);
+                        conn.send_datagram(buf.freeze())?;
+                    }
                 }
                 UdpRelayMode::Quic(()) => {
+                    let cmd = TuicCommand::new_packet(
+                        assoc_id,
+                        pkt.len() as u16,
+                        TuicAddress::from(addr),
+                    );
                     let mut send = conn.get_send_stream().await?;
                     cmd.write_to(&mut send).await?;
                     send.write_all(&pkt).await?;
@@ -88,15 +122,47 @@ impl Connection {
         }
     }
 
-    pub async fn handle_packet_from(self, assoc_id: u32, pkt: Bytes, addr: Address) {
+    pub async fn handle_packet_from(self, assoc_id: u32, pkt: UdpAssocPacket) {
         self.update_max_udp_relay_packet_size();
-        let display_addr = format!("{addr}");
+        let display_addr = match &pkt {
+            UdpAssocPacket::Regular { addr, .. } => format!("{addr}"),
+            UdpAssocPacket::Long {
+                addr: Some(addr), ..
+            } => format!("{addr}"),
+            _ => String::from("unspecified"),
+        };
 
-        if let Some(recv_pkt_tx) = self.udp_sessions().get(&assoc_id) {
-            log::debug!(
-                "[relay] [task] [associate] [{assoc_id}] [recv] [{display_addr}] [success]"
-            );
-            let _ = recv_pkt_tx.send((pkt, addr)).await;
+        if let Some(session) = self.udp_sessions().get(&assoc_id) {
+            match pkt {
+                UdpAssocPacket::Regular { addr, pkt } => {
+                    log::debug!(
+                        "[relay] [task] [associate] [{assoc_id}] [recv] [{display_addr}] [success]"
+                    );
+                    let _ = session.sender().send((pkt, addr.into())).await;
+                }
+                UdpAssocPacket::Long {
+                    lp_id,
+                    frag_id,
+                    frag_cnt,
+                    frag,
+                    addr,
+                } => {
+                    let result = {
+                        let mut lbps = session.lpbs().lock();
+                        lbps.on_frag(lp_id, frag_id, frag_cnt, addr, frag)
+                    };
+                    if let Some((pkt, addr)) = result {
+                        log::debug!(
+                            "[relay] [task] [associate] [{assoc_id}] [recv] [{display_addr}] [long {frag_cnt}] [success]"
+                        );
+                        let _ = session.sender().send((pkt, addr.into())).await;
+                    } else {
+                        log::debug!(
+                            "[relay] [task] [associate] [{assoc_id}] [recv] [{display_addr}] [long {frag_id}/{frag_cnt}]"
+                        );
+                    }
+                }
+            }
         } else {
             log::warn!("[relay] [task] [associate] [{assoc_id}] [recv] [{display_addr}] No corresponding UDP relay session found");
         }

--- a/client/src/socks5/associate.rs
+++ b/client/src/socks5/associate.rs
@@ -81,6 +81,7 @@ async fn socks5_to_relay(
     loop {
         let buf_size = relay::MAX_UDP_RELAY_PACKET_SIZE.load(Ordering::Acquire)
             - (TuicCommand::max_serialized_len() - UdpHeader::max_serialized_len());
+        log::debug!("buf size {buf_size}");
         socket.set_max_packet_size(buf_size);
 
         let (pkt, frag, dst_addr, src_addr) = socket.recv_from().await?;
@@ -104,9 +105,10 @@ async fn socks5_to_relay(
     loop {
         let buf_size = relay::MAX_UDP_RELAY_PACKET_SIZE.load(Ordering::Acquire)
             - (TuicCommand::max_serialized_len() - UdpHeader::max_serialized_len());
+        log::debug!("buf size {buf_size}");
         socket.set_max_packet_size(buf_size);
 
-        let (pkt, frag, dst_addr) = socket.recv().await?;
+        let (pkt, frag, dst_addr, src_addr) = socket.recv_from().await?;
 
         if frag == 0 {
             log::debug!("[socks5] [{ctrl_addr}] [associate] [packet-to] {dst_addr}");

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuic-protocol"
-version = "4.1.1"
+version = "5.0.0"
 authors = ["EAimTY <ea.imty@gmail.com>"]
 description = ""
 categories = ["network-programming"]

--- a/protocol/src/long_packet.rs
+++ b/protocol/src/long_packet.rs
@@ -1,0 +1,82 @@
+//! Packet reassembly buffers for long fragmented UDP packets.
+
+use std::collections::HashMap;
+
+use bytes::{Bytes, BytesMut};
+
+use crate::Address;
+
+#[derive(Clone)]
+pub struct LongPacketBuffer {
+    recv_cnt: u8,
+    frags: Vec<Option<Bytes>>,
+    addr: Option<Address>,
+}
+
+impl LongPacketBuffer {
+    pub fn new(frag_cnt: u8) -> Self {
+        Self {
+            recv_cnt: 0,
+            frags: vec![None; frag_cnt as usize],
+            addr: None,
+        }
+    }
+
+    pub fn set_addr(&mut self, addr: Address) {
+        self.addr = Some(addr);
+    }
+
+    pub fn on_frag(&mut self, frag_id: u8, frag: Bytes) -> Option<(Bytes, Address)> {
+        if (frag_id as usize) < self.frags.len() {
+            let target = &mut self.frags[frag_id as usize];
+            if target.is_none() {
+                self.recv_cnt += 1;
+                *target = Some(frag);
+                if self.recv_cnt as usize == self.frags.len() {
+                    let mut packet = BytesMut::new();
+                    for frag in &mut self.frags {
+                        packet.extend(frag.as_ref().unwrap());
+                    }
+                    return Some((packet.freeze(), self.addr.as_ref().unwrap().clone()));
+                }
+            }
+        }
+        None
+    }
+}
+
+pub struct LongPacketBuffers(HashMap<u32, LongPacketBuffer>);
+
+impl LongPacketBuffers {
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    pub fn on_frag(
+        &mut self,
+        lp_id: u32,
+        frag_id: u8,
+        frag_cnt: u8,
+        addr: Option<Address>,
+        frag: Bytes,
+    ) -> Option<(Bytes, Address)> {
+        let buf = self
+            .0
+            .entry(lp_id)
+            .or_insert_with(|| LongPacketBuffer::new(frag_cnt));
+        if let Some(addr) = addr {
+            buf.set_addr(addr);
+        }
+        if let Some(result) = buf.on_frag(frag_id, frag) {
+            self.0.remove(&lp_id);
+            return Some(result);
+        }
+        None
+    }
+}
+
+impl Default for LongPacketBuffers {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
Under "native" mode the max size of UDP packets is no longer capped by QUIC's max datagram size and is now only determined by the value in config. This is done by adding a LongPacket command along side Packet which contains fragmentation info (the protocol is hence upgraded to v5 but is still backwards compatible). 

The long packet reassembly buffer does not yet have an expiration timer so incomplete packet fragments might accumulate in memory. Not an issue for the time being.

Testing shows that the first couple of packets may be dropped silently even on stable connections, but that's acceptable for UDP.

Addresses both https://github.com/EAimTY/tuic/issues/61 and https://github.com/EAimTY/tuic/issues/63.