### PR TITLE
fix: add set_reuse_address to prevent bind error

### DIFF
--- a/client/src/socks5/mod.rs
+++ b/client/src/socks5/mod.rs
@@ -38,6 +38,7 @@ impl Socks5 {
         } else {
             let socket = Socket::new(Domain::IPV6, Type::STREAM, Some(Protocol::TCP))?;
             socket.set_only_v6(false)?;
+            socket.set_reuse_address(true)?;
             socket.bind(&SockAddr::from(local_addr))?;
             socket.listen(128)?;
             TcpListener::from_std(StdTcpListener::from(socket))?


### PR DESCRIPTION
When the client restarts, some socks clients' connections stay in the `FIN-WAIT` state. Which prevents the client from going up again immediately.