### PR TITLE
Fix cargo doc test failure

### DIFF
--- a/tuic-client/README.md
+++ b/tuic-client/README.md
@@ -29,7 +29,7 @@ tuic-client -c PATH/TO/CONFIG
 
 ## Configuration
 
-```
+```json5
 {
     // Settings for the outbound TUIC proxy
     "relay": {

--- a/tuic-server/README.md
+++ b/tuic-server/README.md
@@ -29,7 +29,7 @@ tuic-server -c PATH/TO/CONFIG
 
 ## Configuration
 
-```
+```json5
 {
     // The socket address to listen on
     "server": "[::]:443",

--- a/tuic/README.md
+++ b/tuic/README.md
@@ -20,7 +20,7 @@ The root of the protocol abstraction is the [`Header`](https://docs.rs/tuic/late
 
 ## Versioning Syntax
 
-```
+```text
 5.0.0-rc0
 ^ ^ ^  ^
 | | |  |- Pre-release version, considered to be unstable


### PR DESCRIPTION
Fix failure:
At current HEAD a299ef02d9f4ab5a0edbf58b9998f41bf768b332, run `cargo test`

```
...
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests tuic

running 1 test
test src/lib.rs - (line 23) ... FAILED

failures:

---- src/lib.rs - (line 23) stdout ----
error: expected expression, found `^`
 --> src/lib.rs:25:3
  |
4 | ^ ^ ^  ^
  |   ^ expected expression

error: aborting due to previous error

Couldn't compile the test.

failures:
    src/lib.rs - (line 23)

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

error: doctest failed, to rerun pass `-p tuic --doc`
```

BTW sincerely recommend attaching `Cargo.lock` to repo in future versions.
Link https://github.com/NixOS/nixpkgs/pull/238489